### PR TITLE
Add MathHelper to round down cost

### DIFF
--- a/angular-electron/src/app/shared/helpers/math.helper.ts
+++ b/angular-electron/src/app/shared/helpers/math.helper.ts
@@ -1,0 +1,5 @@
+export class MathHelper {
+	static roundDownToNearestTenCents(num: number): number {
+		return Math.ceil(num * 10) / 10;
+	}
+}

--- a/angular-electron/src/app/shared/pipes/time-to-cost.pipe.ts
+++ b/angular-electron/src/app/shared/pipes/time-to-cost.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { MathHelper } from '../helpers/math.helper';
 import { CustomerService } from '../services/customer.service';
 
 @Pipe({
@@ -9,7 +10,11 @@ export class TimeToCostPipe implements PipeTransform {
 		private readonly customerService: CustomerService,
 	) { }
 
-	transform(tableNumber: number, clockDate: Date): number {
-		return this.customerService.runningCostForCustomer(tableNumber, clockDate);
+	transform(tableNumber: number, clockDate: Date): string {
+		const cost = this.customerService.runningCostForCustomer(tableNumber, clockDate);
+
+		const roundedDownCost = MathHelper.roundDownToNearestTenCents(cost);
+
+		return roundedDownCost.toFixed(2);
 	}
 }


### PR DESCRIPTION
Always rounding down to nearest 10 cents. Potentially less disputes if we're always rounding down, and we try not to deal in 5 cent blocks which is why we round to 10 cents.